### PR TITLE
ci: checkout role-sdk for workflow dependency resolution

### DIFF
--- a/.github/workflows/ci-analyze.yml
+++ b/.github/workflows/ci-analyze.yml
@@ -15,6 +15,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Checkout role-sdk
+        uses: actions/checkout@v4
+        with:
+          repository: role-suite/role-sdk
+          path: role-sdk
+          token: ${{ secrets.ROLE_SDK_REPO_TOKEN || github.token }}
+
+      - name: Create role_sdk override
+        run: |
+          cat > pubspec_overrides.yaml <<'EOF'
+          dependency_overrides:
+            role_sdk:
+              path: role-sdk/generated/dart/role_sdk
+          EOF
+
       - uses: subosito/flutter-action@v2
         with:
           channel: stable

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -15,6 +15,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Checkout role-sdk
+        uses: actions/checkout@v4
+        with:
+          repository: role-suite/role-sdk
+          path: role-sdk
+          token: ${{ secrets.ROLE_SDK_REPO_TOKEN || github.token }}
+
+      - name: Create role_sdk override
+        run: |
+          cat > pubspec_overrides.yaml <<'EOF'
+          dependency_overrides:
+            role_sdk:
+              path: role-sdk/generated/dart/role_sdk
+          EOF
+
       - uses: subosito/flutter-action@v2
         with:
           channel: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Checkout role-sdk
+        uses: actions/checkout@v4
+        with:
+          repository: role-suite/role-sdk
+          path: role-sdk
+          token: ${{ secrets.ROLE_SDK_REPO_TOKEN || github.token }}
+
+      - name: Create role_sdk override
+        run: |
+          cat > pubspec_overrides.yaml <<'EOF'
+          dependency_overrides:
+            role_sdk:
+              path: role-sdk/generated/dart/role_sdk
+          EOF
+
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -41,6 +56,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+
+      - name: Checkout role-sdk
+        uses: actions/checkout@v4
+        with:
+          repository: role-suite/role-sdk
+          path: role-sdk
+          token: ${{ secrets.ROLE_SDK_REPO_TOKEN || github.token }}
+
+      - name: Create role_sdk override
+        run: |
+          cat > pubspec_overrides.yaml <<'EOF'
+          dependency_overrides:
+            role_sdk:
+              path: role-sdk/generated/dart/role_sdk
+          EOF
 
       - uses: subosito/flutter-action@v2
         with:
@@ -117,6 +147,32 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Checkout role-sdk
+        uses: actions/checkout@v4
+        with:
+          repository: role-suite/role-sdk
+          path: role-sdk
+          token: ${{ secrets.ROLE_SDK_REPO_TOKEN || github.token }}
+
+      - name: Create role_sdk override (non-Windows)
+        if: runner.os != 'Windows'
+        run: |
+          cat > pubspec_overrides.yaml <<'EOF'
+          dependency_overrides:
+            role_sdk:
+              path: role-sdk/generated/dart/role_sdk
+          EOF
+
+      - name: Create role_sdk override (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          @"
+          dependency_overrides:
+            role_sdk:
+              path: role-sdk/generated/dart/role_sdk
+          "@ | Set-Content pubspec_overrides.yaml
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Summary
- Fixes CI failures on PRs to `main` caused by `role_sdk` path dependency not existing on GitHub runners.
- Updates workflows to checkout `role-suite/role-sdk` into the workspace before dependency resolution.
- Adds CI-only `pubspec_overrides.yaml` generation so `role_sdk` resolves from `role-sdk/generated/dart/role_sdk` in Actions.
## What Changed
- `.github/workflows/ci-analyze.yml`
  - Added `Checkout role-sdk` step.
  - Added `Create role_sdk override` step before `flutter pub get`.
- `.github/workflows/ci-test.yml`
  - Added `Checkout role-sdk` step.
  - Added `Create role_sdk override` step before `flutter pub get`.
- `.github/workflows/release.yml`
  - Added `Checkout role-sdk` + override generation in `analyze` and `test` jobs.
  - Added the same override generation in `build-all` matrix job (including Windows-compatible file write).
## Why
- `pubspec.yaml` references:
  - `role_sdk: path: ../role-sdk/generated/dart/role_sdk`
- On CI runners, only `role-client` is checked out by default, so `flutter pub get` fails with:
  - `could not find package role_sdk at "../role-sdk/generated/dart/role_sdk"`
## Validation
- Local analyze/test commands pass.
- Workflow logic now ensures required SDK source is present before dependency resolution in CI.
## Notes
- If `role-suite/role-sdk` is private and default token access is restricted, set:
  - `ROLE_SDK_REPO_TOKEN` (PAT with read access to `role-suite/role-sdk`)